### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/json_client.dart
+++ b/lib/json_client.dart
@@ -173,7 +173,7 @@ class JsonClient {
       if (responseFilter != null) responseFilter(httpRes);
 
       StringBuffer sb = new StringBuffer();
-      httpRes.transform(new AsciiDecoder(allowInvalid: true))
+      new AsciiDecoder(allowInvalid: true).bind(httpRes)
         .listen((String data){
           sb.write(data);
         })


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
